### PR TITLE
Add domain and use-case layers to flights service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/backend/flights-service/src/controllers/flightController.js
+++ b/backend/flights-service/src/controllers/flightController.js
@@ -1,9 +1,10 @@
-const Flight = require('../models/Flight');
 const { validationResult } = require('express-validator');
+const listFlights = require('../use-cases/listFlights');
+const createFlightUseCase = require('../use-cases/createFlight');
 
 exports.getFlights = async (req, res, next) => {
   try {
-    const flights = await Flight.find();
+    const flights = await listFlights();
     res.json(flights);
   } catch (err) {
     next(err);
@@ -14,7 +15,7 @@ exports.createFlight = async (req, res, next) => {
   try {
     const errors = validationResult(req);
     if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
-    const flight = await Flight.create(req.body);
+    const flight = await createFlightUseCase(req.body);
     res.status(201).json(flight);
   } catch (err) {
     next(err);

--- a/backend/flights-service/src/domain/Flight.js
+++ b/backend/flights-service/src/domain/Flight.js
@@ -1,0 +1,11 @@
+class Flight {
+  constructor({ id, origin, destination, date, price }) {
+    this.id = id;
+    this.origin = origin;
+    this.destination = destination;
+    this.date = date;
+    this.price = price;
+  }
+}
+
+module.exports = Flight;

--- a/backend/flights-service/src/domain/FlightRepository.js
+++ b/backend/flights-service/src/domain/FlightRepository.js
@@ -1,0 +1,30 @@
+const FlightModel = require('../models/Flight');
+const Flight = require('./Flight');
+
+class FlightRepository {
+  async list() {
+    const flights = await FlightModel.find();
+    return flights.map((f) =>
+      new Flight({
+        id: f._id.toString(),
+        origin: f.origin,
+        destination: f.destination,
+        date: f.date,
+        price: f.price,
+      })
+    );
+  }
+
+  async create(data) {
+    const flight = await FlightModel.create(data);
+    return new Flight({
+      id: flight._id.toString(),
+      origin: flight.origin,
+      destination: flight.destination,
+      date: flight.date,
+      price: flight.price,
+    });
+  }
+}
+
+module.exports = new FlightRepository();

--- a/backend/flights-service/src/use-cases/createFlight.js
+++ b/backend/flights-service/src/use-cases/createFlight.js
@@ -1,0 +1,5 @@
+const flightRepository = require('../domain/FlightRepository');
+
+module.exports = async function createFlight(data) {
+  return await flightRepository.create(data);
+};

--- a/backend/flights-service/src/use-cases/listFlights.js
+++ b/backend/flights-service/src/use-cases/listFlights.js
@@ -1,0 +1,5 @@
+const flightRepository = require('../domain/FlightRepository');
+
+module.exports = async function listFlights() {
+  return await flightRepository.list();
+};


### PR DESCRIPTION
## Summary
- refactor flight controller to delegate to use cases
- add Flight entity and repository for domain layer
- add use cases for listing and creating flights
- ignore node_modules in git

## Testing
- `cd backend/flights-service && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4231f5898832789b5698ad3016133