### PR TITLE
Add Jest tests and GitHub Actions pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install and test flights-service
+        working-directory: backend/flights-service
+        run: |
+          npm install
+          npm test
+      - name: Install and test payments-service
+        working-directory: backend/payments-service
+        run: |
+          npm install
+          npm test
+      - name: Install and test reservations-service
+        working-directory: backend/reservations-service
+        run: |
+          npm install
+          npm test
+      - name: Install and test users-service
+        working-directory: backend/users-service
+        run: |
+          npm install
+          npm test

--- a/backend/flights-service/package.json
+++ b/backend/flights-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
-    "test": "echo \"No tests\""
+    "test": "jest"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -16,5 +16,8 @@
     "mongoose": "^7.0.3",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^4.6.3"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/backend/flights-service/src/domain/__tests__/Flight.test.js
+++ b/backend/flights-service/src/domain/__tests__/Flight.test.js
@@ -1,0 +1,17 @@
+const Flight = require('../Flight');
+
+describe('Flight entity', () => {
+  test('should create a flight with provided properties', () => {
+    const data = {
+      id: '1',
+      origin: 'AAA',
+      destination: 'BBB',
+      date: new Date('2023-01-01'),
+      price: 100,
+    };
+
+    const flight = new Flight(data);
+
+    expect(flight).toEqual(data);
+  });
+});


### PR DESCRIPTION
## Summary
- add initial Jest test for Flight domain model
- update Flights Service package.json to use Jest
- configure GitHub Actions workflow to run tests for all services

## Testing
- `npm install` *(fails: 403 Forbidden fetching jest)*
- `npm test` *(fails: jest command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f80b6c18832784b0c576c38a0aad