### PR TITLE
Add Jest tests and GitHub Actions pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install and test flights-service
+        working-directory: backend/flights-service
+        run: |
+          npm install
+          npm test
+      - name: Install and test payments-service
+        working-directory: backend/payments-service
+        run: |
+          npm install
+          npm test
+      - name: Install and test reservations-service
+        working-directory: backend/reservations-service
+        run: |
+          npm install
+          npm test
+      - name: Install and test users-service
+        working-directory: backend/users-service
+        run: |
+          npm install
+          npm test

--- a/backend/flights-service/package.json
+++ b/backend/flights-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
-    "test": "echo \"No tests\""
+    "test": "jest"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -16,5 +16,8 @@
     "mongoose": "^7.0.3",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^4.6.3"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/backend/flights-service/src/controllers/flightController.js
+++ b/backend/flights-service/src/controllers/flightController.js
@@ -5,6 +5,7 @@ const getFlightUseCase = require('../use-cases/getFlight');
 const updateFlightUseCase = require('../use-cases/updateFlight');
 const deleteFlightUseCase = require('../use-cases/deleteFlight');
 const seedFlightsUseCase = require('../use-cases/seedFlights');
+const Flight = require('../models/Flight');
 
 exports.getFlights = async (req, res, next) => {
   try {
@@ -24,10 +25,11 @@ exports.getUserFlights = async (req, res, next) => {
   }
 };
 
-exports.getUserFlights = async (req, res, next) => {
+exports.getFlight = async (req, res, next) => {
   try {
-    const flights = await Flight.find({ user: req.user.id });
-    res.json(flights);
+    const flight = await getFlightUseCase(req.params.id);
+    if (!flight) return res.sendStatus(404);
+    res.json(flight);
   } catch (err) {
     next(err);
   }
@@ -37,7 +39,7 @@ exports.createFlight = async (req, res, next) => {
   try {
     const errors = validationResult(req);
     if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
-    const flight = await Flight.create({ ...req.body, user: req.user.id });
+    const flight = await createFlightUseCase({ ...req.body, user: req.user.id });
     res.status(201).json(flight);
   } catch (err) {
     next(err);

--- a/backend/flights-service/src/domain/__tests__/Flight.test.js
+++ b/backend/flights-service/src/domain/__tests__/Flight.test.js
@@ -1,0 +1,17 @@
+const Flight = require('../Flight');
+
+describe('Flight entity', () => {
+  test('should create a flight with provided properties', () => {
+    const data = {
+      id: '1',
+      origin: 'AAA',
+      destination: 'BBB',
+      date: new Date('2023-01-01'),
+      price: 100,
+    };
+
+    const flight = new Flight(data);
+
+    expect(flight).toEqual(data);
+  });
+});

--- a/backend/flights-service/src/routes/flightRoutes.js
+++ b/backend/flights-service/src/routes/flightRoutes.js
@@ -1,6 +1,14 @@
 const express = require('express');
 const { body } = require('express-validator');
-const { getFlights, createFlight, getUserFlights } = require('../controllers/flightController');
+const {
+  getFlights,
+  getFlight,
+  createFlight,
+  updateFlight,
+  deleteFlight,
+  getUserFlights,
+  seedFlights: seedFlightsController,
+} = require('../controllers/flightController');
 const auth = require('../middleware/auth');
 const router = express.Router();
 
@@ -12,25 +20,17 @@ const router = express.Router();
  */
 router.get('/', getFlights);
 
-router.post('/seed', auth, seedFlights);
+router.post('/seed', auth, seedFlightsController);
+
+/**
+ * @swagger
+ * /api/flights/mine:
+ *   get:
+ *     summary: List flights for user
+ */
+router.get('/mine', auth, getUserFlights);
 
 router.get('/:id', getFlight);
-
-/**
- * @swagger
- * /api/flights/mine:
- *   get:
- *     summary: List flights for user
- */
-router.get('/mine', auth, getUserFlights);
-
-/**
- * @swagger
- * /api/flights/mine:
- *   get:
- *     summary: List flights for user
- */
-router.get('/mine', auth, getUserFlights);
 
 /**
  * @swagger

--- a/backend/payments-service/package.json
+++ b/backend/payments-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
-    "test": "echo \"No tests\""
+    "test": "jest"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -15,5 +15,8 @@
     "jsonwebtoken": "^9.0.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^4.6.3"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/backend/payments-service/src/domain/__tests__/Payment.test.js
+++ b/backend/payments-service/src/domain/__tests__/Payment.test.js
@@ -1,0 +1,16 @@
+const Payment = require('../Payment');
+
+describe('Payment entity', () => {
+  test('should create a payment with provided properties', () => {
+    const data = {
+      id: '1',
+      reservation: 'res-1',
+      amount: 100,
+      status: 'pending',
+    };
+
+    const payment = new Payment(data);
+
+    expect(payment).toEqual(data);
+  });
+});

--- a/backend/reservations-service/package.json
+++ b/backend/reservations-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
-    "test": "echo \"No tests\""
+    "test": "jest"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -16,5 +16,8 @@
     "mongoose": "^7.0.3",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^4.6.3"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/backend/reservations-service/src/domain/__tests__/Reservation.test.js
+++ b/backend/reservations-service/src/domain/__tests__/Reservation.test.js
@@ -1,0 +1,16 @@
+const Reservation = require('../Reservation');
+
+describe('Reservation entity', () => {
+  test('should create a reservation with provided properties', () => {
+    const data = {
+      id: '1',
+      user: 'user-1',
+      flight: 'flight-1',
+      status: 'confirmed',
+    };
+
+    const reservation = new Reservation(data);
+
+    expect(reservation).toEqual(data);
+  });
+});

--- a/backend/users-service/package.json
+++ b/backend/users-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
-    "test": "echo \"No tests\""
+    "test": "jest"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
@@ -17,5 +17,8 @@
     "mongoose": "^7.0.3",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^4.6.3"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/backend/users-service/src/domain/__tests__/User.test.js
+++ b/backend/users-service/src/domain/__tests__/User.test.js
@@ -1,0 +1,16 @@
+const User = require('../User');
+
+describe('User entity', () => {
+  test('should create a user with provided properties', () => {
+    const data = {
+      id: '1',
+      name: 'John Doe',
+      email: 'john@example.com',
+      password: 'secret',
+    };
+
+    const user = new User(data);
+
+    expect(user).toEqual(data);
+  });
+});


### PR DESCRIPTION
## Summary
- add initial Jest test for Flight domain model
- update Flights Service package.json to use Jest
- configure GitHub Actions workflow to run tests for all services
- add unit tests for Payment, Reservation, and User domain models
- enable Jest test scripts in payments, reservations, and users services
- expose all Flight controller methods and correct route ordering
- alias seed flights handler to avoid undefined reference error

## Testing
- `npm test` (flights-service) *(fails: jest: not found)*
- `npm install` (flights-service) *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f80b6c18832784b0c576c38a0aad